### PR TITLE
Update thunderbird-daily.desktop

### DIFF
--- a/thunderbird-daily.desktop
+++ b/thunderbird-daily.desktop
@@ -12,7 +12,7 @@ Icon=/opt/daily/chrome/icons/default/default128.png
 #Categories=Network;Email;News;GTK;
 # Also don't associate Icedove with the MIME types.
 #MimeType=message/rfc822;x-scheme-handler/mailto;text/calendar;text/x-vcard;
-StartupWMClass=Thunderbird
+StartupWMClass=thunderbird-nightly
 StartupNotify=true
 Name[ast]=Veceru de corréu Icedove -> Thunderbird
 Name[ca]=Client de correu Icedove -> Thunderbird

--- a/thunderbird-daily.desktop
+++ b/thunderbird-daily.desktop
@@ -2,12 +2,12 @@
 Name=Thunderbird
 Comment=Read/Write Mail/News with Thunderbird
 GenericName=Mail Client
-Exec=/opt/thunderbird/thunderbird %u
+Exec=/opt/daily/thunderbird %u
 Terminal=false
 X-MultipleArgs=false
 Type=Application
 Version=1.0
-Icon=thunderbird
+Icon=/opt/daily/chrome/icons/default/default128.png
 # Don't show up this (transitional) desktop file in the Categories.
 #Categories=Network;Email;News;GTK;
 # Also don't associate Icedove with the MIME types.


### PR DESCRIPTION
link to the correct Exec and Icon file so the Desktop icon will appear

fixes #2 

the `postinst` moves everything to `/opt/daily` 
https://github.com/Vitexus/ThunderbirdDailyDeb/blob/606a4ee6507e048dfa7e8c27cb8ae63953b2ead7/debian/postinst#L15

so the exec file is found in `/opt/daily` not in `/opt/thunderbird` like the current .desktop file is looking for 
https://github.com/Vitexus/ThunderbirdDailyDeb/blob/606a4ee6507e048dfa7e8c27cb8ae63953b2ead7/thunderbird-daily.desktop#L5