### PR TITLE
make wget and tar less noisy

### DIFF
--- a/debian/preinst
+++ b/debian/preinst
@@ -20,12 +20,12 @@ esac
 
 VERSION=$(curl -s https://archive.mozilla.org/pub/thunderbird/nightly/latest-comm-central-l10n/ | grep /pub/thunderbird/nightly/latest-comm-central-l10n | awk -F'"' '{print $2}' |  cut -c 63- | awk -F. '{ print $1 "." $2 }' | tail -n 1)
 
-wget "https://ftp.mozilla.org/pub/thunderbird/nightly/latest-comm-central-l10n/thunderbird-${VERSION}.${LANGCODE}.linux-${archs}.tar.xz" -O $TMPFILE
+wget -q "https://ftp.mozilla.org/pub/thunderbird/nightly/latest-comm-central-l10n/thunderbird-${VERSION}.${LANGCODE}.linux-${archs}.tar.xz" -O $TMPFILE
 cd /tmp
 mkdir -p $DESTDIR
 rm -rf "$DESTDIR/*"
 ls -l $DESTDIR
-tar xJvf $TMPFILE -C $DESTDIR --strip-components=1
+tar xJf $TMPFILE -C $DESTDIR --strip-components=1
 rm $TMPFILE
 
 # End of debian/preinst


### PR DESCRIPTION
would it be a problem to make `tar` and `wget` less noisy while installing?

added `-q` to `wget` and removed `v` from `tar`