### PR TITLE
Tweak/less noise during install

### DIFF
--- a/debian/preinst
+++ b/debian/preinst
@@ -22,7 +22,6 @@ wget -q "https://ftp.mozilla.org/pub/thunderbird/nightly/latest-comm-central-l10
 cd /tmp
 mkdir -p $DESTDIR
 rm -rf "$DESTDIR/*"
-ls -l $DESTDIR
 tar xJf $TMPFILE -C $DESTDIR --strip-components=1
 rm $TMPFILE
 

--- a/debian/preinst
+++ b/debian/preinst
@@ -6,10 +6,8 @@ LANGCODE=$(echo $LANG | awk -F_ '{print $1}')
 case $LANGCODE in
 en|es|fy|ga) LANGCODE=$(echo $LANG | sed -e 's/_/-/g' | awk -F. '{print $1}') ;;
 C.UTF-8 ) LANGCODE="en-US" ;;
-*) echo "$LANGCODE" ;;
+*) ;;
 esac
-
-echo "Current Language is ⁝$LANG⁝ = ⁝$LANGCODE⁝"
 
 archs=$(uname -m)
 case "$archs" in


### PR DESCRIPTION
took out a couple `echo` statements and the `ls -la` from the preinst 


also would it be ok to remove the `echo` statement found in the postinst on line 4

 https://github.com/Vitexus/ThunderbirdDailyDeb/blob/e272c9f38d416a03e624e2e8d568ddb196368bc5/debian/postinst#L3-L5