### PR TITLE
clean working directory (/tmp/*) before using to ensure no duplicate data

### DIFF
--- a/debian/preinst
+++ b/debian/preinst
@@ -3,6 +3,9 @@ DESTDIR="/tmp/daily"
 TMPFILE="/tmp/thunderbird.tar.xz"
 LANGCODE=$(echo "$LANG" | awk -F_ '{print $1}')
 
+rm -rf "$DESTDIR"
+rm -rf "$TMPFILE"
+
 #Obtain Langcodes available: links -dump https://archive.mozilla.org/pub/thunderbird/nightly/latest-comm-central-l10n/ | grep linux | awk '{print $2}' | grep -v asc | grep -v mar | grep -v checksums | awk -F. '{print $3}' | sort | uniq
 
 SUPPORTED_LANGCODES="af ar ast be bg br ca cak cs cy da de dsb el en-CA en-GB en-US es-AR es-ES es-MX et eu fi fr fy-NL ga-IE gd gl he hr hsb hu hy-AM id is it ja ka kab kk ko lt lv mk ms nb-NO nl nn-NO pa-IN pl pt-BR pt-PT rm ro ru sk sl sq sr sv-SE th tr uk uz vi zh-CN zh-TW"
@@ -38,7 +41,6 @@ VERSION=$(curl -s https://archive.mozilla.org/pub/thunderbird/nightly/latest-com
 wget -q "https://ftp.mozilla.org/pub/thunderbird/nightly/latest-comm-central-l10n/thunderbird-${VERSION}.${LANGCODE}.linux-${archs}.tar.xz" -O $TMPFILE
 cd /tmp
 mkdir -p $DESTDIR
-rm -rf "$DESTDIR/*"
 ls -l $DESTDIR
 tar xJf $TMPFILE -C $DESTDIR --strip-components=1
 rm $TMPFILE


### PR DESCRIPTION
`rm -rf` does not throw errors for directories or files that do not exist so remove them before attempting to use them to ensure what is put there is all that is there