### PR TITLE
less noise, less depends, & ensure the tmp directories are empty before use

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Standards-Version: 3.9.2
 Package: thunderbird-daily
 Architecture: all
 Replaces: daily
-Depends: debianutils (>= 1.16), fontconfig, psmisc, x11-utils, ${misc:Depends}, ${shlibs:Depends},curl,wget
+Depends: debianutils (>= 1.16), fontconfig, psmisc, x11-utils, ${misc:Depends}, ${shlibs:Depends}, curl
 Provides: mail-reader, thunderbird,
 Description: mail/news client with RSS, chat and integrated spam filter support
  Thunderbird is an mail client suitable for free distribution.

--- a/debian/preinst
+++ b/debian/preinst
@@ -3,6 +3,9 @@ DESTDIR="/tmp/daily"
 TMPFILE="/tmp/thunderbird.tar.xz"
 LANGCODE=$(echo "$LANG" | awk -F_ '{print $1}')
 
+rm -rf "$DESTDIR"
+rm -rf "$TMPFILE"
+
 #Obtain Langcodes available: links -dump https://archive.mozilla.org/pub/thunderbird/nightly/latest-comm-central-l10n/ | grep linux | awk '{print $2}' | grep -v asc | grep -v mar | grep -v checksums | awk -F. '{print $3}' | sort | uniq
 
 SUPPORTED_LANGCODES="af ar ast be bg br ca cak cs cy da de dsb el en-CA en-GB en-US es-AR es-ES es-MX et eu fi fr fy-NL ga-IE gd gl he hr hsb hu hy-AM id is it ja ka kab kk ko lt lv mk ms nb-NO nl nn-NO pa-IN pl pt-BR pt-PT rm ro ru sk sl sq sr sv-SE th tr uk uz vi zh-CN zh-TW"
@@ -38,7 +41,6 @@ VERSION=$(curl -s https://archive.mozilla.org/pub/thunderbird/nightly/latest-com
 wget -q "https://ftp.mozilla.org/pub/thunderbird/nightly/latest-comm-central-l10n/thunderbird-${VERSION}.${LANGCODE}.linux-${archs}.tar.xz" -O $TMPFILE
 cd /tmp
 mkdir -p $DESTDIR
-rm -rf "$DESTDIR/*"
 tar xJf $TMPFILE -C $DESTDIR --strip-components=1
 rm $TMPFILE
 

--- a/debian/preinst
+++ b/debian/preinst
@@ -38,7 +38,7 @@ esac
 
 VERSION=$(curl -s https://archive.mozilla.org/pub/thunderbird/nightly/latest-comm-central-l10n/ | grep /pub/thunderbird/nightly/latest-comm-central-l10n | awk -F'"' '{print $2}' | cut -c 63- | awk -F. '{ print $1 "." $2 }' | tail -n 1)
 
-wget -q "https://ftp.mozilla.org/pub/thunderbird/nightly/latest-comm-central-l10n/thunderbird-${VERSION}.${LANGCODE}.linux-${archs}.tar.xz" -O $TMPFILE
+curl -s "https://ftp.mozilla.org/pub/thunderbird/nightly/latest-comm-central-l10n/thunderbird-${VERSION}.${LANGCODE}.linux-${archs}.tar.xz" -o $TMPFILE
 cd /tmp
 mkdir -p $DESTDIR
 tar xJf $TMPFILE -C $DESTDIR --strip-components=1

--- a/debian/preinst
+++ b/debian/preinst
@@ -39,7 +39,6 @@ wget -q "https://ftp.mozilla.org/pub/thunderbird/nightly/latest-comm-central-l10
 cd /tmp
 mkdir -p $DESTDIR
 rm -rf "$DESTDIR/*"
-ls -l $DESTDIR
 tar xJf $TMPFILE -C $DESTDIR --strip-components=1
 rm $TMPFILE
 


### PR DESCRIPTION
this accomplishes 3 things

1. removes `ls -la` from `preinst` for less noise during install 

2. removes `wget` from depends and moves to only `curl` not sure both are needed since they can both accomplish the task at hand. 

3.  move `rm -rf "$DESTDIR"` to top of `preinst` and also add `rm -rf "$TMPFILE"` under it to ensure clean working directories


i thought about it and figured one p/r was better than multiple